### PR TITLE
added coercion support for Debezium time types via annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 ## [Unreleased]
 
+- Added support for coercion of Debezium time types to formatted `string` values using type annotations.
+
 ## [0.2.4] - 2023-03-13
 
 -   Added support for `double` primitive type fields.
 -   Allow coercion of iceberg table identifiers to `snake_case` setting `table.snake-case` boolean configuration.
-
 ## [0.2.2] - 2023-02-17
 
 -   Allow changing iceberg-table specific settings using `iceberg.table-default.*` connector configuration properties

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## [Unreleased]
 
-- Added support for coercion of two Debezium time types: Date and MicroTimestamp
+- Added support for coercion of five Debezium temporal types to their Iceberg equivalents: Date, MicroTimestamp, ZonedTimestamp, MicroTime, and ZonedTime
+- Rich temporal types are toggled on by new boolean configuration property: `rich-temporal-types`
 
 ## [0.2.5] - 2023-03-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## [Unreleased]
 
-- Reverted pom.xml groupid
+## [0.2.5] - 2023-03-20
+
+-   Reverted pom.xml groupid
 
 ## [0.2.4] - 2023-03-13
 
@@ -41,7 +43,9 @@ Kafka Connect >= 3.2.3 has updated the jackson version to an incompatible minor 
 
 -   First release
 
-[Unreleased]: https://github.com/getindata/kafka-connect-iceberg-sink/compare/0.2.4...HEAD
+[Unreleased]: https://github.com/getindata/kafka-connect-iceberg-sink/compare/0.2.5...HEAD
+
+[0.2.5]: https://github.com/getindata/kafka-connect-iceberg-sink/compare/0.2.4...0.2.5
 
 [0.2.4]: https://github.com/getindata/kafka-connect-iceberg-sink/compare/0.2.2...0.2.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Reverted pom.xml groupid
+
 ## [0.2.4] - 2023-03-13
 
 -   Added support for `double` primitive type fields.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Added support for coercion of Debezium time types to formatted `string` values using type annotations.
+
 ## [0.2.5] - 2023-03-20
 
 -   Reverted pom.xml groupid
@@ -10,7 +12,6 @@
 
 -   Added support for `double` primitive type fields.
 -   Allow coercion of iceberg table identifiers to `snake_case` setting `table.snake-case` boolean configuration.
-
 ## [0.2.2] - 2023-02-17
 
 -   Allow changing iceberg-table specific settings using `iceberg.table-default.*` connector configuration properties

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.getindata</groupId>
     <artifactId>kafka-connect-iceberg-sink</artifactId>
-    <version>0.2.4-SNAPSHOT</version>
+    <version>0.2.5</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.getindata</groupId>
     <artifactId>kafka-connect-iceberg-sink</artifactId>
-    <version>0.2.5</version>
+    <version>0.2.5-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>reifyhealth</groupId>
+    <groupId>com.getindata</groupId>
     <artifactId>kafka-connect-iceberg-sink</artifactId>
     <version>0.2.4-SNAPSHOT</version>
     <packaging>jar</packaging>

--- a/src/main/java/com/getindata/kafka/connect/iceberg/sink/IcebergChangeEvent.java
+++ b/src/main/java/com/getindata/kafka/connect/iceberg/sink/IcebergChangeEvent.java
@@ -152,7 +152,7 @@ public class IcebergChangeEvent {
                                      JsonNode node) {
     String fieldTypeName = field.doc();
     LOGGER.debug("Processing Field:{} Type:{} Doc:{}",
-                field.name(), field.type(), fieldTypeName);
+                 field.name(), field.type(), fieldTypeName);
 
     final Object val;
     switch (field.type().typeId()) {
@@ -173,17 +173,21 @@ public class IcebergChangeEvent {
         break;
       case STRING:
         // string destination coercions based upon schema 'name' annotations
-        if (IcebergChangeEvent.coerceDebeziumDate && fieldTypeName.equals("io.debezium.time.Date")) {
-          val = node.isNull() ? null : LocalDate.ofEpochDay(node.asInt()).toString();
+        if (IcebergChangeEvent.coerceDebeziumDate &&
+            fieldTypeName.equals("io.debezium.time.Date")) {
+          val = node.isNull() ? null
+                : LocalDate.ofEpochDay(node.asInt()).toString();
         }
         else {
           if (IcebergChangeEvent.coerceDebeziumMicroTimestamp &&
               fieldTypeName.equals("io.debezium.time.MicroTimestamp")) {
-            val = node.isNull() ? null : Instant.ofEpochSecond(0L, node.asLong() * 1000).toString();
+            val = node.isNull() ? null
+                  : Instant.ofEpochSecond(0L, node.asLong() * 1000).toString();
           }
           else {
             // if the node is not a value node (method isValueNode returns false), convert it to string.
-            val = node.isValueNode() ? node.asText(null) : node.toString();
+            val = node.isValueNode() ? node.asText(null)
+                  : node.toString();
           }
         }
         break;

--- a/src/main/java/com/getindata/kafka/connect/iceberg/sink/IcebergChangeEvent.java
+++ b/src/main/java/com/getindata/kafka/connect/iceberg/sink/IcebergChangeEvent.java
@@ -181,7 +181,7 @@ public class IcebergChangeEvent {
         break;
       case TIMESTAMP:
         if (node.isTextual()) {
-          val = ZonedDateTime.parse(node.asText());
+          val = OffsetDateTime.parse(node.asText());
         }
         else if (node.isNumber()) {
           Instant instant = Instant.ofEpochSecond(0L, node.asLong() * 1000);

--- a/src/main/java/com/getindata/kafka/connect/iceberg/sink/IcebergSinkConfiguration.java
+++ b/src/main/java/com/getindata/kafka/connect/iceberg/sink/IcebergSinkConfiguration.java
@@ -11,6 +11,8 @@ import static org.apache.kafka.common.config.ConfigDef.Importance.MEDIUM;
 import static org.apache.kafka.common.config.ConfigDef.Type.BOOLEAN;
 import static org.apache.kafka.common.config.ConfigDef.Type.STRING;
 
+import com.getindata.kafka.connect.iceberg.sink.IcebergChangeEvent;
+
 public class IcebergSinkConfiguration {
     public static final String UPSERT = "upsert";
     public static final String UPSERT_KEEP_DELETES = "upsert.keep-deletes";
@@ -21,6 +23,8 @@ public class IcebergSinkConfiguration {
     public static final String TABLE_PREFIX = "table.prefix";
     public static final String TABLE_AUTO_CREATE = "table.auto-create";
     public static final String TABLE_SNAKE_CASE = "table.snake-case";
+    public static final String COERCE_DEBEZIUM_DATE = "coerce.debezium-date";
+    public static final String COERCE_DEBEZIUM_MICRO_TIMESTAMP = "coerce.debezium-micro-timestamp";
     public static final String ICEBERG_PREFIX = "iceberg.";
     public static final String ICEBERG_TABLE_PREFIX = "iceberg.table-default";
     public static final String CATALOG_NAME = ICEBERG_PREFIX + "name";
@@ -48,6 +52,11 @@ public class IcebergSinkConfiguration {
                     "Prefix added to all table names")
             .define(TABLE_SNAKE_CASE, BOOLEAN, false, MEDIUM,
                     "Coerce table names to snake_case")
+            .define(COERCE_DEBEZIUM_DATE, BOOLEAN, false, MEDIUM,
+                    "Coerce int32 values with 'io.debezium.time.Date' annotation to local-date strings")
+            .define(COERCE_DEBEZIUM_MICRO_TIMESTAMP, BOOLEAN, false, MEDIUM,
+                    "Coerce int64 values with 'io.debezium.time.MicroTimestamp' annotation to" +
+                            "iso datetime strings")
             .define(CATALOG_NAME, STRING, "default", MEDIUM,
                     "Iceberg catalog name")
             .define(CATALOG_IMPL, STRING, null, MEDIUM,
@@ -102,10 +111,18 @@ public class IcebergSinkConfiguration {
         return parsedConfig.getBoolean(TABLE_SNAKE_CASE);
     }
 
+    public boolean isCoerceDebeziumDate() {
+        return parsedConfig.getBoolean(COERCE_DEBEZIUM_DATE);
+    }
+
+    public boolean isCoerceDebeziumMicroTimestamp() {
+        return parsedConfig.getBoolean(COERCE_DEBEZIUM_MICRO_TIMESTAMP);
+    }
+
     public String getCatalogName() {
         return parsedConfig.getString(CATALOG_NAME);
     }
-    
+
     public Map<String, String> getIcebergCatalogConfiguration() {
         return getConfiguration(ICEBERG_PREFIX);
     }
@@ -128,5 +145,10 @@ public class IcebergSinkConfiguration {
 
     public Map<String, String> getProperties() {
         return properties;
+    }
+
+    public void configureChangeEvent() {
+        IcebergChangeEvent.setCoerceDebeziumDate(this.isCoerceDebeziumDate());
+        IcebergChangeEvent.setCoerceDebeziumMicroTimestamp(this.isCoerceDebeziumMicroTimestamp());
     }
 }

--- a/src/main/java/com/getindata/kafka/connect/iceberg/sink/IcebergSinkConfiguration.java
+++ b/src/main/java/com/getindata/kafka/connect/iceberg/sink/IcebergSinkConfiguration.java
@@ -11,8 +11,6 @@ import static org.apache.kafka.common.config.ConfigDef.Importance.MEDIUM;
 import static org.apache.kafka.common.config.ConfigDef.Type.BOOLEAN;
 import static org.apache.kafka.common.config.ConfigDef.Type.STRING;
 
-import com.getindata.kafka.connect.iceberg.sink.IcebergChangeEvent;
-
 public class IcebergSinkConfiguration {
     public static final String UPSERT = "upsert";
     public static final String UPSERT_KEEP_DELETES = "upsert.keep-deletes";
@@ -23,8 +21,7 @@ public class IcebergSinkConfiguration {
     public static final String TABLE_PREFIX = "table.prefix";
     public static final String TABLE_AUTO_CREATE = "table.auto-create";
     public static final String TABLE_SNAKE_CASE = "table.snake-case";
-    public static final String COERCE_DEBEZIUM_DATE = "coerce.debezium-date";
-    public static final String COERCE_DEBEZIUM_MICRO_TIMESTAMP = "coerce.debezium-micro-timestamp";
+    public static final String RICH_TEMPORAL_TYPES = "rich-temporal-types";
     public static final String ICEBERG_PREFIX = "iceberg.";
     public static final String ICEBERG_TABLE_PREFIX = "iceberg.table-default";
     public static final String CATALOG_NAME = ICEBERG_PREFIX + "name";
@@ -52,11 +49,9 @@ public class IcebergSinkConfiguration {
                     "Prefix added to all table names")
             .define(TABLE_SNAKE_CASE, BOOLEAN, false, MEDIUM,
                     "Coerce table names to snake_case")
-            .define(COERCE_DEBEZIUM_DATE, BOOLEAN, false, MEDIUM,
-                    "Coerce int32 values with 'io.debezium.time.Date' annotation to local-date strings")
-            .define(COERCE_DEBEZIUM_MICRO_TIMESTAMP, BOOLEAN, false, MEDIUM,
-                    "Coerce int64 values with 'io.debezium.time.MicroTimestamp' annotation to" +
-                            "iso datetime strings")
+            .define(RICH_TEMPORAL_TYPES, BOOLEAN, false, MEDIUM,
+                    "Coerce Debezium Date, MicroTimestamp, ZonedTimestamp, MicroTime, and ZonedTime values " +
+                            "from JSON primitives to their corresponding Iceberg rich types")
             .define(CATALOG_NAME, STRING, "default", MEDIUM,
                     "Iceberg catalog name")
             .define(CATALOG_IMPL, STRING, null, MEDIUM,
@@ -111,12 +106,8 @@ public class IcebergSinkConfiguration {
         return parsedConfig.getBoolean(TABLE_SNAKE_CASE);
     }
 
-    public boolean isCoerceDebeziumDate() {
-        return parsedConfig.getBoolean(COERCE_DEBEZIUM_DATE);
-    }
-
-    public boolean isCoerceDebeziumMicroTimestamp() {
-        return parsedConfig.getBoolean(COERCE_DEBEZIUM_MICRO_TIMESTAMP);
+    public boolean isRichTemporalTypes() {
+        return parsedConfig.getBoolean(RICH_TEMPORAL_TYPES);
     }
 
     public String getCatalogName() {
@@ -145,10 +136,5 @@ public class IcebergSinkConfiguration {
 
     public Map<String, String> getProperties() {
         return properties;
-    }
-
-    public void configureChangeEvent() {
-        IcebergChangeEvent.setCoerceDebeziumDate(this.isCoerceDebeziumDate());
-        IcebergChangeEvent.setCoerceDebeziumMicroTimestamp(this.isCoerceDebeziumMicroTimestamp());
     }
 }

--- a/src/main/java/com/getindata/kafka/connect/iceberg/sink/IcebergSinkTask.java
+++ b/src/main/java/com/getindata/kafka/connect/iceberg/sink/IcebergSinkTask.java
@@ -26,11 +26,9 @@ public class IcebergSinkTask extends SinkTask {
     public void start(Map<String, String> properties) {
         LOGGER.info("Task starting");
         IcebergSinkConfiguration configuration = new IcebergSinkConfiguration(properties);
-        // provide type coercion configuration IcebergChangeEvent
-        configuration.configureChangeEvent();
         Catalog icebergCatalog = IcebergCatalogFactory.create(configuration);
         IcebergTableOperator icebergTableOperator = IcebergTableOperatorFactory.create(configuration);
-        SinkRecordToIcebergChangeEventConverter converter = SinkRecordToIcebergChangeEventConverterFactory.create();
+        SinkRecordToIcebergChangeEventConverter converter = SinkRecordToIcebergChangeEventConverterFactory.create(configuration);
         consumer = new IcebergChangeConsumer(configuration, icebergCatalog, icebergTableOperator, converter);
     }
 

--- a/src/main/java/com/getindata/kafka/connect/iceberg/sink/IcebergSinkTask.java
+++ b/src/main/java/com/getindata/kafka/connect/iceberg/sink/IcebergSinkTask.java
@@ -26,6 +26,8 @@ public class IcebergSinkTask extends SinkTask {
     public void start(Map<String, String> properties) {
         LOGGER.info("Task starting");
         IcebergSinkConfiguration configuration = new IcebergSinkConfiguration(properties);
+        // provide type coercion configuration IcebergChangeEvent
+        configuration.configureChangeEvent();
         Catalog icebergCatalog = IcebergCatalogFactory.create(configuration);
         IcebergTableOperator icebergTableOperator = IcebergTableOperatorFactory.create(configuration);
         SinkRecordToIcebergChangeEventConverter converter = SinkRecordToIcebergChangeEventConverterFactory.create();

--- a/src/main/java/com/getindata/kafka/connect/iceberg/sink/converter/SinkRecordToIcebergChangeEventConverter.java
+++ b/src/main/java/com/getindata/kafka/connect/iceberg/sink/converter/SinkRecordToIcebergChangeEventConverter.java
@@ -3,6 +3,7 @@ package com.getindata.kafka.connect.iceberg.sink.converter;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.getindata.kafka.connect.iceberg.sink.IcebergChangeEvent;
+import com.getindata.kafka.connect.iceberg.sink.IcebergSinkConfiguration;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.json.JsonConverter;
@@ -19,17 +20,19 @@ public class SinkRecordToIcebergChangeEventConverter {
     private final JsonConverter valueJsonConverter;
     private final Deserializer<JsonNode> keyDeserializer;
     private final Deserializer<JsonNode> valueDeserializer;
+    private final IcebergSinkConfiguration configuration;
 
     public SinkRecordToIcebergChangeEventConverter(Transformation<SinkRecord> extractNewRecordStateTransformation,
                                                    JsonConverter keyJsonConverter,
                                                    JsonConverter valueJsonConverter,
                                                    Deserializer<JsonNode> keyDeserializer,
-                                                   Deserializer<JsonNode> valueDeserializer) {
+                                                   Deserializer<JsonNode> valueDeserializer, IcebergSinkConfiguration configuration) {
         this.extractNewRecordStateTransformation = extractNewRecordStateTransformation;
         this.keyJsonConverter = keyJsonConverter;
         this.valueJsonConverter = valueJsonConverter;
         this.keyDeserializer = keyDeserializer;
         this.valueDeserializer = valueDeserializer;
+        this.configuration = configuration;
     }
 
     public IcebergChangeEvent convert(SinkRecord record) {
@@ -41,7 +44,7 @@ public class SinkRecordToIcebergChangeEventConverter {
         JsonNode value = getValue(unwrappedRecord.topic(), valueDeserializer, valueBytes);
         JsonNode valueSchema = getSchema(valueBytes);
 
-        return new IcebergChangeEvent(unwrappedRecord.topic(), value, key, valueSchema, keySchema);
+        return new IcebergChangeEvent(unwrappedRecord.topic(), value, key, valueSchema, keySchema, configuration);
     }
 
     private JsonNode getValue(String topic, Deserializer<JsonNode> deserializer, byte[] bytes) {

--- a/src/main/java/com/getindata/kafka/connect/iceberg/sink/converter/SinkRecordToIcebergChangeEventConverter.java
+++ b/src/main/java/com/getindata/kafka/connect/iceberg/sink/converter/SinkRecordToIcebergChangeEventConverter.java
@@ -26,7 +26,8 @@ public class SinkRecordToIcebergChangeEventConverter {
                                                    JsonConverter keyJsonConverter,
                                                    JsonConverter valueJsonConverter,
                                                    Deserializer<JsonNode> keyDeserializer,
-                                                   Deserializer<JsonNode> valueDeserializer, IcebergSinkConfiguration configuration) {
+                                                   Deserializer<JsonNode> valueDeserializer,
+                                                   IcebergSinkConfiguration configuration) {
         this.extractNewRecordStateTransformation = extractNewRecordStateTransformation;
         this.keyJsonConverter = keyJsonConverter;
         this.valueJsonConverter = valueJsonConverter;

--- a/src/main/java/com/getindata/kafka/connect/iceberg/sink/converter/SinkRecordToIcebergChangeEventConverterFactory.java
+++ b/src/main/java/com/getindata/kafka/connect/iceberg/sink/converter/SinkRecordToIcebergChangeEventConverterFactory.java
@@ -1,13 +1,14 @@
 package com.getindata.kafka.connect.iceberg.sink.converter;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.getindata.kafka.connect.iceberg.sink.IcebergSinkConfiguration;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.connect.json.JsonConverter;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.transforms.Transformation;
 
 public class SinkRecordToIcebergChangeEventConverterFactory {
-    public static SinkRecordToIcebergChangeEventConverter create() {
+    public static SinkRecordToIcebergChangeEventConverter create(IcebergSinkConfiguration configuration) {
         Transformation<SinkRecord> extractNewRecordStateTransformation = ExtractNewRecordStateTransformationFactory.create();
         JsonConverter keyJsonConverter = JsonConverterFactory.create(true);
         JsonConverter valueJsonConverter = JsonConverterFactory.create(false);
@@ -17,7 +18,7 @@ public class SinkRecordToIcebergChangeEventConverterFactory {
                 extractNewRecordStateTransformation,
                 keyJsonConverter,
                 valueJsonConverter,
-                keyDeserializer, valueDeserializer
-        );
+                keyDeserializer, valueDeserializer,
+                configuration);
     }
 }

--- a/src/test/java/com/getindata/kafka/connect/iceberg/sink/TestIcebergUtil.java
+++ b/src/test/java/com/getindata/kafka/connect/iceberg/sink/TestIcebergUtil.java
@@ -50,7 +50,8 @@ class TestIcebergUtil {
     public void testNestedJsonRecord() throws JsonProcessingException {
         IcebergChangeEvent e = new IcebergChangeEvent("test",
                 MAPPER.readTree(serdeWithSchema).get("payload"), null,
-                MAPPER.readTree(serdeWithSchema).get("schema"), null, this.defaultConfiguration);
+                MAPPER.readTree(serdeWithSchema).get("schema"), null,
+                this.defaultConfiguration);
         Schema schema = e.icebergSchema();
         assertTrue(schema.toString().contains("before: optional struct<2: id: optional int (), 3: first_name: optional string (), " +
                 "4:"));
@@ -60,7 +61,8 @@ class TestIcebergUtil {
     public void testUnwrapJsonRecord() throws IOException {
         IcebergChangeEvent e = new IcebergChangeEvent("test",
                 MAPPER.readTree(unwrapWithSchema).get("payload"), null,
-                MAPPER.readTree(unwrapWithSchema).get("schema"), null, this.defaultConfiguration);
+                MAPPER.readTree(unwrapWithSchema).get("schema"), null,
+                this.defaultConfiguration);
         Schema schema = e.icebergSchema();
         GenericRecord record = e.asIcebergRecord(schema);
         assertEquals("orders", record.getField("__table").toString());
@@ -71,7 +73,8 @@ class TestIcebergUtil {
     public void testNestedArrayJsonRecord() throws JsonProcessingException {
         IcebergChangeEvent e = new IcebergChangeEvent("test",
                 MAPPER.readTree(unwrapWithArraySchema).get("payload"), null,
-                MAPPER.readTree(unwrapWithArraySchema).get("schema"), null, this.defaultConfiguration);
+                MAPPER.readTree(unwrapWithArraySchema).get("schema"), null,
+                this.defaultConfiguration);
         Schema schema = e.icebergSchema();
         assertTrue(schema.asStruct().toString().contains("struct<1: name: optional string (), 2: pay_by_quarter: optional list<int> (), 4: schedule: optional list<string> (), 6:"));
         System.out.println(schema.findField("pay_by_quarter").type().asListType().elementType());
@@ -87,7 +90,8 @@ class TestIcebergUtil {
         assertThrows(RuntimeException.class, () -> {
             IcebergChangeEvent e = new IcebergChangeEvent("test",
                     MAPPER.readTree(unwrapWithArraySchema2).get("payload"), null,
-                    MAPPER.readTree(unwrapWithArraySchema2).get("schema"), null, this.defaultConfiguration);
+                    MAPPER.readTree(unwrapWithArraySchema2).get("schema"), null,
+                    this.defaultConfiguration);
             Schema schema = e.icebergSchema();
             System.out.println(schema.asStruct());
             System.out.println(schema);
@@ -100,7 +104,8 @@ class TestIcebergUtil {
     public void testNestedGeomJsonRecord() throws JsonProcessingException {
         IcebergChangeEvent e = new IcebergChangeEvent("test",
                 MAPPER.readTree(unwrapWithGeomSchema).get("payload"), null,
-                MAPPER.readTree(unwrapWithGeomSchema).get("schema"), null, this.defaultConfiguration);
+                MAPPER.readTree(unwrapWithGeomSchema).get("schema"), null,
+                this.defaultConfiguration);
         Schema schema = e.icebergSchema();
         GenericRecord record = e.asIcebergRecord(schema);
         assertTrue(schema.toString().contains("g: optional struct<3: wkb: optional string (), 4: srid: optional int ()>"));

--- a/src/test/java/com/getindata/kafka/connect/iceberg/sink/TestIcebergUtil.java
+++ b/src/test/java/com/getindata/kafka/connect/iceberg/sink/TestIcebergUtil.java
@@ -47,7 +47,7 @@ class TestIcebergUtil {
                 MAPPER.readTree(serdeWithSchema).get("payload"), null,
                 MAPPER.readTree(serdeWithSchema).get("schema"), null);
         Schema schema = e.icebergSchema();
-        assertTrue(schema.toString().contains("before: optional struct<2: id: optional int, 3: first_name: optional string, " +
+        assertTrue(schema.toString().contains("before: optional struct<2: id: optional int (), 3: first_name: optional string (), " +
                 "4:"));
     }
 
@@ -70,8 +70,7 @@ class TestIcebergUtil {
                 MAPPER.readTree(unwrapWithArraySchema).get("payload"), null,
                 MAPPER.readTree(unwrapWithArraySchema).get("schema"), null);
         Schema schema = e.icebergSchema();
-        assertTrue(schema.asStruct().toString().contains("struct<1: name: optional string, 2: pay_by_quarter: optional list<int>, 4: schedule: optional list<string>, 6:"));
-        System.out.println(schema.asStruct());
+        assertTrue(schema.asStruct().toString().contains("struct<1: name: optional string (), 2: pay_by_quarter: optional list<int> (), 4: schedule: optional list<string> (), 6:"));
         System.out.println(schema.findField("pay_by_quarter").type().asListType().elementType());
         System.out.println(schema.findField("schedule").type().asListType().elementType());
         assertEquals(schema.findField("pay_by_quarter").type().asListType().elementType().toString(), "int");
@@ -101,7 +100,7 @@ class TestIcebergUtil {
                 MAPPER.readTree(unwrapWithGeomSchema).get("schema"), null);
         Schema schema = e.icebergSchema();
         GenericRecord record = e.asIcebergRecord(schema);
-        assertTrue(schema.toString().contains("g: optional struct<3: wkb: optional string, 4: srid: optional int>"));
+        assertTrue(schema.toString().contains("g: optional struct<3: wkb: optional string (), 4: srid: optional int ()>"));
         GenericRecord g = (GenericRecord) record.getField("g");
         GenericRecord h = (GenericRecord) record.getField("h");
         assertEquals("AQEAAAAAAAAAAADwPwAAAAAAAPA/", g.get(0, Types.StringType.get().typeId().javaClass()));

--- a/src/test/java/com/getindata/kafka/connect/iceberg/sink/TestIcebergUtil.java
+++ b/src/test/java/com/getindata/kafka/connect/iceberg/sink/TestIcebergUtil.java
@@ -232,7 +232,7 @@ class TestIcebergUtil {
         GenericRecord record = e.asIcebergRecord(schema);
         assertEquals(record.getField("ship_date"), LocalDate.parse("2182-08-20"));
         assertEquals(record.getField("ship_timestamp"), LocalDateTime.parse("2182-08-19T21:50:56.016196"));
-        assertEquals(record.getField("ship_timestamp_zoned"), ZonedDateTime.parse("2023-04-11T20:32:46.821144Z"));
+        assertEquals(record.getField("ship_timestamp_zoned"), OffsetDateTime.parse("2023-04-11T20:32:46.821144Z"));
         assertEquals(record.getField("ship_time"), LocalTime.ofNanoOfDay(73966821144L * 1000));
         assertEquals(record.getField("ship_time_zoned"), OffsetTime.parse("20:32:46.821144Z").toLocalTime());
     }

--- a/src/test/java/com/getindata/kafka/connect/iceberg/sink/testresources/IcebergChangeEventBuilder.java
+++ b/src/test/java/com/getindata/kafka/connect/iceberg/sink/testresources/IcebergChangeEventBuilder.java
@@ -13,7 +13,9 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.getindata.kafka.connect.iceberg.sink.IcebergChangeEvent;
+import com.getindata.kafka.connect.iceberg.sink.IcebergSinkConfiguration;
 
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
@@ -27,6 +29,8 @@ public class IcebergChangeEventBuilder {
   ObjectNode payload = JsonNodeFactory.instance.objectNode();
   ObjectNode keyPayload = JsonNodeFactory.instance.objectNode();
   String destination = "test";
+
+  private final IcebergSinkConfiguration defaultConfiguration = new IcebergSinkConfiguration(new HashMap());
 
   public IcebergChangeEventBuilder() {
   }
@@ -104,8 +108,8 @@ public class IcebergChangeEventBuilder {
         payload,
         keyPayload,
         this.valueSchema(),
-        this.keySchema()
-    );
+        this.keySchema(),
+        this.defaultConfiguration);
   }
 
   private ObjectNode valueSchema() {

--- a/src/test/java/com/getindata/kafka/connect/iceberg/sink/testresources/TestConfig.java
+++ b/src/test/java/com/getindata/kafka/connect/iceberg/sink/testresources/TestConfig.java
@@ -64,6 +64,11 @@ public class TestConfig {
             return this;
         }
 
+        public Builder withCustomProperty(String key, String value) {
+            properties.put(key, value);
+            return this;
+        }
+
         public IcebergSinkConfiguration build() {
             return new IcebergSinkConfiguration(properties);
         }

--- a/src/test/resources/json/debezium-annotated-schema.json
+++ b/src/test/resources/json/debezium-annotated-schema.json
@@ -1,0 +1,37 @@
+{
+  "schema": {
+    "type": "struct",
+    "fields": [
+      {
+        "type": "int32",
+        "optional": false,
+        "field": "id"
+      },
+      {
+        "type": "int32",
+        "optional": false,
+        "name": "io.debezium.time.Date",
+        "version": 1,
+        "field": "ship_date"
+      },
+      {
+        "type": "int64",
+        "optional": true,
+        "name": "io.debezium.time.MicroTimestamp",
+        "field": "ship_timestamp"
+      }
+    ],
+    "optional": false,
+    "name": "testc.ship.time.Value"
+  },
+  "payload": {
+    "id": 10003,
+    "ship_date": 77663,
+    "ship_timestamp": 6710075456016196,
+    "__op": "r",
+    "__table": "time",
+    "__lsn": 33832960,
+    "__source_ts_ms": 1596309876678,
+    "__deleted": "false"
+  }
+}

--- a/src/test/resources/json/debezium-annotated-schema.json
+++ b/src/test/resources/json/debezium-annotated-schema.json
@@ -19,6 +19,28 @@
         "optional": true,
         "name": "io.debezium.time.MicroTimestamp",
         "field": "ship_timestamp"
+      },
+      {
+        "type": "string",
+        "optional": true,
+        "name": "io.debezium.time.ZonedTimestamp",
+        "version": 1,
+        "field": "ship_timestamp_zoned"
+      },
+      {
+        "type": "int64",
+        "optional": true,
+        "name": "io.debezium.time.MicroTime",
+        "version": 1,
+        "default": 0,
+        "field": "ship_time"
+      },
+      {
+        "type": "string",
+        "optional": true,
+        "name": "io.debezium.time.ZonedTime",
+        "version": 1,
+        "field": "ship_time_zoned"
       }
     ],
     "optional": false,
@@ -28,6 +50,9 @@
     "id": 10003,
     "ship_date": 77663,
     "ship_timestamp": 6710075456016196,
+    "ship_timestamp_zoned": "2023-04-11T20:32:46.821144Z",
+    "ship_time": 73966821144,
+    "ship_time_zoned": "20:32:46.821144Z",
     "__op": "r",
     "__table": "time",
     "__lsn": 33832960,


### PR DESCRIPTION
#### Description

added coercion support for Debezium time types via annotations.
Provides "human-readable" local-date and microsecond timestamp coercions from fixed-point integer types to formatted strings.
Behavior is switchable via configuration flags, and is disabled by default for backwards compatibility.

##### PR Checklist
- [x] Tests added
- [x] [Changelog](CHANGELOG.md) updated 

[DE-1488]

[DE-1488]: https://reifyhealth.atlassian.net/browse/DE-1488?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ