### PR TITLE
Added recursive Array<Struct> support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Added Iceberg coercion support for Avro Array<Struct> types. Supports Debezium `data_collections` metadata.
 - Added support for coercion of five Debezium temporal types to their Iceberg equivalents: Date, MicroTimestamp, ZonedTimestamp, MicroTime, and ZonedTime
 - Rich temporal types are toggled on by new boolean configuration property: `rich-temporal-types`
 

--- a/src/test/java/com/getindata/kafka/connect/iceberg/sink/TestIcebergUtil.java
+++ b/src/test/java/com/getindata/kafka/connect/iceberg/sink/TestIcebergUtil.java
@@ -31,6 +31,7 @@ import java.time.*;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.ArrayList;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -43,6 +44,7 @@ class TestIcebergUtil {
     final String unwrapWithArraySchema = Testing.Files.readResourceAsString("json/serde-with-array.json");
     final String unwrapWithArraySchema2 = Testing.Files.readResourceAsString("json/serde-with-array2.json");
     final String debeziumTimeCoercionSchema = Testing.Files.readResourceAsString("json/debezium-annotated-schema.json");
+    final String debeziumMetadataSchema = Testing.Files.readResourceAsString("json/debezium-metadata-schema.json");
 
     private final IcebergSinkConfiguration defaultConfiguration = new IcebergSinkConfiguration(new HashMap());
 
@@ -240,6 +242,36 @@ class TestIcebergUtil {
         assertEquals(record.getField("ship_timestamp_zoned"), OffsetDateTime.parse("2023-04-11T20:32:46.821144Z"));
         assertEquals(record.getField("ship_time"), LocalTime.ofNanoOfDay(73966821144L * 1000));
         assertEquals(record.getField("ship_time_zoned"), OffsetTime.parse("20:32:46.821144Z").toLocalTime());
+    }
+
+    @Test
+    public void listStructSchemaHandling()
+      throws JsonProcessingException {
+        IcebergChangeEvent e = new IcebergChangeEvent("test",
+                                          MAPPER.readTree(debeziumMetadataSchema).get("payload"), null,
+                                          MAPPER.readTree(debeziumMetadataSchema).get("schema"), null);
+        Schema schema = e.icebergSchema();
+        String schemaString = schema.toString();
+
+        GenericRecord record = e.asIcebergRecord(schema);
+
+        assertTrue(schemaString.contains("data_collections: optional list<struct"));
+
+        GenericRecord innerRecord = (GenericRecord) ((ArrayList) record.getField("data_collections")).get(0);
+        Object value = innerRecord.getField("data_collection");
+        assertTrue(value.equals("public.mine"));
+
+        value = innerRecord.getField("event_count");
+        assertTrue((long) value == 1);
+
+        value = record.getField("status");
+        assertTrue(((String) value).equals("END"));
+
+        value = record.getField("id");
+        assertTrue(((String) value).equals("12117:67299632"));
+
+        value = record.getField("ts_ms");
+        assertTrue(((long) value) == 1680821545908L);
     }
 
     @Test

--- a/src/test/java/com/getindata/kafka/connect/iceberg/sink/TestIcebergUtil.java
+++ b/src/test/java/com/getindata/kafka/connect/iceberg/sink/TestIcebergUtil.java
@@ -249,7 +249,9 @@ class TestIcebergUtil {
       throws JsonProcessingException {
         IcebergChangeEvent e = new IcebergChangeEvent("test",
                                           MAPPER.readTree(debeziumMetadataSchema).get("payload"), null,
-                                          MAPPER.readTree(debeziumMetadataSchema).get("schema"), null);
+                                          MAPPER.readTree(debeziumMetadataSchema).get("schema"), null,
+                                          defaultConfiguration
+        );
         Schema schema = e.icebergSchema();
         String schemaString = schema.toString();
 

--- a/src/test/java/com/getindata/kafka/connect/iceberg/sink/TestIcebergUtil.java
+++ b/src/test/java/com/getindata/kafka/connect/iceberg/sink/TestIcebergUtil.java
@@ -248,9 +248,9 @@ class TestIcebergUtil {
     public void listStructSchemaHandling()
       throws JsonProcessingException {
         IcebergChangeEvent e = new IcebergChangeEvent("test",
-                                          MAPPER.readTree(debeziumMetadataSchema).get("payload"), null,
-                                          MAPPER.readTree(debeziumMetadataSchema).get("schema"), null,
-                                          defaultConfiguration
+                MAPPER.readTree(debeziumMetadataSchema).get("payload"), null,
+                MAPPER.readTree(debeziumMetadataSchema).get("schema"), null,
+                defaultConfiguration
         );
         Schema schema = e.icebergSchema();
         String schemaString = schema.toString();
@@ -261,19 +261,19 @@ class TestIcebergUtil {
 
         GenericRecord innerRecord = (GenericRecord) ((ArrayList) record.getField("data_collections")).get(0);
         Object value = innerRecord.getField("data_collection");
-        assertTrue(value.equals("public.mine"));
+        assertEquals("public.mine", value);
 
         value = innerRecord.getField("event_count");
-        assertTrue((long) value == 1);
+        assertEquals(1L, value);
 
         value = record.getField("status");
-        assertTrue(((String) value).equals("END"));
+        assertEquals("END", value);
 
         value = record.getField("id");
-        assertTrue(((String) value).equals("12117:67299632"));
+        assertEquals("12117:67299632", value);
 
         value = record.getField("ts_ms");
-        assertTrue(((long) value) == 1680821545908L);
+        assertEquals(1680821545908L, value);
     }
 
     @Test

--- a/src/test/resources/json/debezium-metadata-schema.json
+++ b/src/test/resources/json/debezium-metadata-schema.json
@@ -1,0 +1,65 @@
+{
+  "schema": {
+    "type": "struct",
+    "fields": [
+      {
+        "type": "string",
+        "optional": false,
+        "field": "status"
+      },
+      {
+        "type": "string",
+        "optional": false,
+        "field": "id"
+      },
+      {
+        "type": "int64",
+        "optional": true,
+        "field": "event_count"
+      },
+      {
+        "type": "array",
+        "items": {
+          "type": "struct",
+          "fields": [
+            {
+              "type": "string",
+              "optional": false,
+              "field": "data_collection"
+            },
+            {
+              "type": "int64",
+              "optional": false,
+              "field": "event_count"
+            }
+          ],
+          "optional": true,
+          "name": "event.collection",
+          "version": 1
+        },
+        "optional": true,
+        "field": "data_collections"
+      },
+      {
+        "type": "int64",
+        "optional": false,
+        "field": "ts_ms"
+      }
+    ],
+    "optional": false,
+    "name": "io.debezium.connector.common.TransactionMetadataValue",
+    "version": 1
+  },
+  "payload": {
+    "status": "END",
+    "id": "12117:67299632",
+    "event_count": 1,
+    "data_collections": [
+      {
+        "data_collection": "public.mine",
+        "event_count": 1
+      }
+    ],
+    "ts_ms": 1680821545908
+  }
+}


### PR DESCRIPTION
#### Description

* Added support for Array types containing nested Struct element types such as: `io.debezium.connector.common.TransactionMetadataValue`.  Added to support metadata via Debezium connector config:    `"provide.transaction.metadata": "true"`

##### PR Checklist
- [x] Tests added
- [x] [Changelog](CHANGELOG.md) updated 
