### PR TITLE
jackson-databind critical CVE repair [DE-1512]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Changelog
 
-- Updates AWS lakeformation transitive dependency providing lakeformation support in s3 iceberg tables.
-
 ## [Unreleased]
 
+- Updates dependencies to resolve some jackson-databind critical CVEs.
+- Updates AWS lakeformation transitive dependency providing lakeformation support in s3 iceberg tables.
 - Added Iceberg coercion support for Avro Array<Struct> types. Supports Debezium `data_collections` metadata.
 - Added support for coercion of five Debezium temporal types to their Iceberg equivalents: Date, MicroTimestamp, ZonedTimestamp, MicroTime, and ZonedTime
 - Rich temporal types are toggled on by new boolean configuration property: `rich-temporal-types`

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.parquet</groupId>
+            <artifactId>parquet-hadoop-bundle</artifactId>
+            <version>1.13.0</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
             <version>${hadoop.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -17,8 +17,8 @@
         <kafka.connect.version>3.2.2</kafka.connect.version>
         <iceberg.version>1.2.1</iceberg.version>
         <debezium.version>1.9.7.Final</debezium.version>
-        <hadoop.version>3.3.3</hadoop.version>
-        <awssdk.version>2.17.295</awssdk.version>
+        <hadoop.version>3.3.5</hadoop.version>
+        <awssdk.version>2.20.51</awssdk.version>
         <hive.version>3.1.3</hive.version>
         <!-- spark 3.2.2_2.13 includes jackson 2.12.3 which requires Jackson Databind version >= 2.12.0 and < 2.13.0 -->
         <!-- jackson is also provided by kafka connect-runtime -> pinning to the same version -->


### PR DESCRIPTION
#### Description

Resolves a set of Jackson-databind related CVEs:

```shell
https://github.com/advisories/GHSA-h822-r4r5-v8jg
https://github.com/advisories/GHSA-qr7j-h6gg-jmgc
https://github.com/advisories/GHSA-p43x-xfjf-5jhr
https://github.com/advisories/GHSA-f3j5-rmmp-3fc5
https://github.com/advisories/GHSA-f3j5-rmmp-3fc5
https://github.com/advisories/GHSA-fmmc-742q-jg75
https://github.com/advisories/GHSA-h592-38cm-4ggp
https://github.com/advisories/GHSA-4gq5-ch57-c2mg
https://github.com/advisories/GHSA-mx7p-6679-8g3q
https://github.com/advisories/GHSA-q93h-jc49-78gg
https://github.com/advisories/GHSA-cggj-fvv3-cqwv
https://github.com/advisories/GHSA-645p-88qh-w398
https://github.com/advisories/GHSA-rfx6-vp9g-rh7v
https://github.com/advisories/GHSA-gjmw-vf9h-g25v
```

##### PR Checklist
- [x] [Changelog](CHANGELOG.md) updated 
